### PR TITLE
Load current EQ settings into drop-down boxes on web interface

### DIFF
--- a/Esp32_radio.ino
+++ b/Esp32_radio.ino
@@ -3551,6 +3551,15 @@ const char* analyzeCmd ( const char* par, const char* val )
   {
     return presetlist.c_str() ;                       // Send preset list as reply
   }
+  else if ( argument == "eq" )
+  {
+    String toneCodes[] = { "HA", "HF", "LA", "LF" };
+    String eq = "" ;
+    for (uint8_t i = 0; i < 4; i++) {
+      eq += toneCodes[i] + String( ini_block.rtone[i] ) + String( '|' ) ;
+    }  
+    return eq.c_str() ;
+  }
   else
   {
     sprintf ( reply, "%s called with illegal parameter: %s",

--- a/index_html.h
+++ b/index_html.h
@@ -8,7 +8,7 @@ const char index_html[] PROGMEM = R"=====(
   <meta http-equiv="content-type" content="text/html; charset=ISO-8859-1">
   <link rel="Shortcut Icon" type="image/ico" href="favicon.ico">
  </head>
- <body>
+ <body onload="initvalues()">
   <ul>
    <li><a class="pull-left" href="#">ESP32 Radio</a></li>
    <li><a class="pull-left active" href="/index.html">Control</a></li>
@@ -25,7 +25,7 @@ const char index_html[] PROGMEM = R"=====(
    <button class="button" onclick="httpGet('stop')">STOP</button>
    <button class="button" onclick="httpGet('resume')">RESUME</button>
    <button class="button" onclick="httpGet('status')">STATUS</button>
-   <button class="button" onclick="httpGet('test')">TEST</button>
+   <button class="button" onclick="httpGet('test')">MEMORY</button>
    <table style="width:500px">
     <tr>
      <td colspan="2"><center>
@@ -50,7 +50,7 @@ const char index_html[] PROGMEM = R"=====(
        <option value="13">-4.5 dB</option>
        <option value="14">-3 dB</option>
        <option value="15">-1.5 dB</option>
-       <option value="0" selected>Off</option>
+       <option value="0">Off</option>
        <option value="1">+1.5 dB</option>
        <option value="2">+3 dB</option>
        <option value="3">+4.5 dB</option>
@@ -90,7 +90,7 @@ const char index_html[] PROGMEM = R"=====(
       <label for="LA"><big>Bass Gain:</big></label>
       <br>
       <select class="select" onChange="handletone(this)" id="LA">
-       <option value="0" selected>Off</option>
+       <option value="0">Off</option>
        <option value="1">+1 dB</option>
        <option value="2">+2 dB</option>
        <option value="3">+3 dB</option>
@@ -214,6 +214,27 @@ const char index_html[] PROGMEM = R"=====(
    }
    xhr.open ( "GET", theUrl, false ) ;
    xhr.send() ;
+   // Fill eq values initially
+   //
+   function initvalues ()
+   {
+     var i, selection, opt, cursettings ;
+     var theUrl = "/?eq" + "&version=" + Math.random() ;
+     var xhr = new XMLHttpRequest() ;
+     xhr.onreadystatechange = function() {
+     if ( xhr.readyState == XMLHttpRequest.DONE )
+     {
+       cursettings = xhr.responseText.split ( "|" ) ;
+       for ( i = 0 ; i < 4 ; i++ )
+       {
+         document.getElementById(cursettings[i].substring(0,2)).value = cursettings[i].substring(2) ;
+       }
+         
+     }
+   }
+   xhr.open ( "GET", theUrl, false ) ;
+   xhr.send() ;
+  }
   </script>
   <script type="text/javascript">
     var stylesheet = document.createElement('link') ;


### PR DESCRIPTION
This seems to be working well enough to post a PR. 

I added a new `"/?eq"` GET method to the `analyzeCmd` function, enabling the web interface (index.html) page to grab the current EQ settings for the 4 drop down selection boxes and display them to the user. This is done using a similar javascript function as you use directly above it. To have it run the function immediately, it is called in the `<body>` tag's `onload` handler. I essentially just followed your `?list` code as an example and modified it to suit the task. 

One thing to note though, it has been YEARS since I have written any sort of javascript, so please do test it thoroughly before committing. 

PS..
The only other changes that I've made was to change the NVS file saving timer to trigger every 30 seconds, and my ringbuffer is currently at 51200 (these chips can support a much larger buffer than the <21000 value necessary for the 8266 chips)
I'm not sure if this will have an effect on the new code nor to what extent that may be, but I did not remember to test that before posting. I suppose I could though..

PPS. My appologies if a fork was not the appropriate way of creating this PR, I couldn't figure out how to create a branch on your repo, so this seemed like the only way of doing it that I could find. Still learning over here...