### PR TITLE
ILI9341 TFT support

### DIFF
--- a/Esp32_radio/Esp32_radio.ino
+++ b/Esp32_radio/Esp32_radio.ino
@@ -137,10 +137,11 @@
 #define VERSION "Wed, 01 Aug 2018 11:20:00 GMT"
 //
 // Define (one) type of display.  See documentation.
-#define BLUETFT                        // Works also for RED TFT 128x160
+//#define BLUETFT                        // Works also for RED TFT 128x160
 //#define OLED                         // 64x128 I2C OLED
 //#define DUMMYTFT                     // Dummy display
 //#define LCD1602I2C                   // LCD 1602 display with I2C backpack
+#define ILI9341                        // ILI9341 240*320
 //
 #include <nvs.h>
 #include <PubSubClient.h>
@@ -406,6 +407,9 @@ enc_menu_t        enc_menu_mode = VOLUME ;               // Default is VOLUME mo
 // Include software for the right display
 #ifdef BLUETFT
 #include "bluetft.h"                                     // For ILI9163C or ST7735S 128x160 display
+#endif
+#ifdef ILI9341
+#include "ILI9341.h"                                     // For ILI9341 320x240 display
 #endif
 #ifdef OLED
 #include "SSD1306.h"                                     // For OLED I2C SD1306 64x128 display
@@ -3106,6 +3110,9 @@ void setup()
              ESP.getFreeHeap() ) ;                       // Normally about 170 kB
   #if defined ( BLUETFT )                                // Report display option
     dbgprint ( dtyp, "BLUETFT" ) ;
+  #endif
+  #if defined ( ILI9341 )                                // Report display option
+    dbgprint ( dtyp, "ILI9341" ) ;
   #endif
   #if defined ( OLED )
     dbgprint ( dtyp, "OLED" ) ;

--- a/Esp32_radio/ILI9341.h
+++ b/Esp32_radio/ILI9341.h
@@ -1,0 +1,61 @@
+// ILI9341.h
+//
+// Contributed by Uksa007@gmail.com
+// Separated from the main sketch to allow several display types.
+// Includes for various ILI9341 displays.  Tested on 320 x 240.
+// Requires Adafruit ILI9341 library, available from library manager.
+// Below set your dsp_getwidth() and dsp_getwidth() to suite your display.
+
+
+#include <Adafruit_ILI9341.h>
+
+// Color definitions for the TFT screen (if used)
+// TFT has bits 6 bits (0..5) for RED, 6 bits (6..11) for GREEN and 4 bits (12..15) for BLUE.
+#define BLACK   ILI9341_BLACK
+#define BLUE    ILI9341_BLUE
+#define RED     ILI9341_RED
+#define GREEN   ILI9341_GREEN
+#define CYAN    GREEN | BLUE
+#define MAGENTA RED | BLUE
+#define YELLOW  RED | GREEN
+#define WHITE   RED | BLUE | GREEN
+
+// Data to display.  There are TFTSECS sections
+#define TFTSECS 4
+scrseg_struct     tftdata[TFTSECS] =                        // Screen divided in 3 segments + 1 overlay
+{                                                           // One text line is 8 pixels
+  { false, WHITE,   0,  8, "" },                            // 1 top line
+  { false, CYAN,   20, 64, "" },                            // 8 lines in the middle
+  { false, YELLOW, 90, 32, "" },                            // 4 lines at the bottom
+  { false, GREEN,  90, 32, "" }                             // 4 lines at the bottom for rotary encoder
+} ;
+
+
+Adafruit_ILI9341*     tft = NULL ;                                  // For instance of display driver
+
+// Various macro's to mimic the ILI9341 version of display functions
+#define dsp_setRotation()       tft->setRotation ( 3 )             // Use landscape format (3 for upside down)
+#define dsp_print(a)            tft->print ( a )                   // Print a string 
+#define dsp_println(b)          tft->println ( b )                 // Print a string followed by newline 
+#define dsp_fillRect(a,b,c,d,e) tft->fillRect ( a, b, c, d, e ) ;  // Fill a rectange
+#define dsp_setTextSize(a)      tft->setTextSize(a)                // Set the text size
+#define dsp_setTextColor(a)     tft->setTextColor(a)               // Set the text color
+#define dsp_setCursor(a,b)      tft->setCursor ( a, b )            // Position the cursor
+#define dsp_erase()             tft->fillScreen ( BLACK ) ;        // Clear the screen
+#define dsp_getwidth()          320                                // Adjust to your display
+#define dsp_getheight()         240                                // Get height of screen
+#define dsp_update()                                               // Updates to the physical screen
+#define dsp_usesSPI()           true                               // Does use SPI
+
+
+bool dsp_begin()
+{
+  tft = new Adafruit_ILI9341( ini_block.tft_cs_pin,
+                              ini_block.tft_dc_pin ) ;        // Create an instant for TFT
+
+  // Uncomment the next 2 lines for ILI9341 displays
+  tft->begin();                                                     // Init TFT interface
+  //tft->fillScreen(ILI9341_BLACK);                                 // Set Black Background
+  
+  return ( tft != NULL ) ;
+}


### PR DESCRIPTION
 Added support for ILI9341 TFT display support. 
Added ILI9341.h
Tested and working with 320x240 display.

Requires Adafruit ILI9341 library, available from library manager.
Make sure you configure the corrent GPIO pins for your display in defaultprefs.h
e.g.:
pin_vs_cs = 33                                       # GPIO Pin number for VS1053 "CS"
pin_vs_dcs = 32                                     # GPIO Pin number for VS1053 "DCS"
pin_vs_dreq = 34                                   # GPIO Pin number for VS1053 "DREQ"