### PR TITLE
Ir repeat code detection

### DIFF
--- a/Esp32_radio/Esp32_radio.ino
+++ b/Esp32_radio/Esp32_radio.ino
@@ -1213,13 +1213,13 @@ void claimSPI ( const char* p )
 
   while ( xSemaphoreTake ( SPIsem, ctry ) != pdTRUE  )      // Claim SPI bus
   {
-//    if ( count++ > 10 )
-//    {
-//      dbgprint ( "SPI semaphore not taken within %d ticks by CPU %d, id %s",
-//                 count * ctry,
-//                 xPortGetCoreID(),
-//                 p ) ;
-//    }
+    if ( count++ > 10 )
+    {
+      dbgprint ( "SPI semaphore not taken within %d ticks by CPU %d, id %s",
+                 count * ctry,
+                 xPortGetCoreID(),
+                 p ) ;
+    }
   }
 }
 

--- a/Esp32_radio/Esp32_radio.ino
+++ b/Esp32_radio/Esp32_radio.ino
@@ -141,6 +141,7 @@
 // 18-09-2018, ES: "uppreset" and "downpreset" for MP3 player.
 // 04-10-2018, ES: Fixed compile error OLED 64x128 display.
 // 09-10-2018, ES: Bug fix xSemaphoreTake.
+// 30-12-2018, DK: Added support for NEC style IR repeat codes
 //
 //
 // Define the version number, also used for webserver as Last-Modified header and to


### PR DESCRIPTION
Fixes #205 
I actually do not know whether Edzelf's original IR routine could also interpret other IR codes (non NEC style). I could not test that because I only have NEC style RCs.
My routine offers an addition to the config string for IR commands. If the commands are not modified repeat codes do not trigger additional commands. If you add a / XXX (where XXX is a integer value > 0) to the command this should result in a repetition of the command after XXX ms. However the repetition interval is restricted by the time it takes until scanir() gets called again, so very short repetition times are useless and might result in unpredictable intervals.

An example from my config:

> ir_301C = downvolume = 1/100  # Apple Remote -
ir_501C = upvolume = 1/100    # Apple Remote +
ir_601C = uppreset = 1/1000   # Apple Remote >>|
ir_901C = downpreset = 1/1000 # Apple Remote |<<
ir_A01C = mute                # Apple Remote >||
ir_C01C = mute                # Apple Remote MENU

I hope you find this useful too!
