### PR TITLE
Recognise Longpress on IR-Remotes

### DIFF
--- a/Esp32_radio/Esp32_radio.ino
+++ b/Esp32_radio/Esp32_radio.ino
@@ -430,7 +430,7 @@ int               chunkcount = 0 ;                       // Counter for chunked 
 String            http_getcmd ;                          // Contents of last GET command
 String            http_rqfile ;                          // Requested file
 bool              http_response_flag = false ;           // Response required
-uint16_t          ir_value = 0 ;                         // IR code
+uint32_t          ir_value = 0 ;                         // IR code
 uint32_t          ir_0 = 550 ;                           // Average duration of an IR short pulse
 uint32_t          ir_1 = 1650 ;                          // Average duration of an IR long pulse
 struct tm         timeinfo ;                             // Will be filled by NTP server
@@ -1695,6 +1695,9 @@ void IRAM_ATTR isr_IR()
   sv uint32_t      t0 = 0 ;                          // To get the interval
   sv uint32_t      ir_locvalue = 0 ;                 // IR code
   sv int           ir_loccount = 0 ;                 // Length of code
+  sv uint32_t      ir_repeatcode = 0;                // Code to report, if repeat shot has been detected
+  sv uint32_t      ir_lasttime = 0;                  // Last time of valid code (either first shot or repeat)
+  sv uint8_t       repeat_step = 0;                  // Current Status of repeat code received
   uint32_t         t1, intval ;                      // Current time and interval since last change
   uint32_t         mask_in = 2 ;                     // Mask input for conversion
   uint16_t         mask_out = 1 ;                    // Mask output for conversion
@@ -1704,9 +1707,25 @@ void IRAM_ATTR isr_IR()
   t0 = t1 ;                                          // Save for next compare
   if ( ( intval > 300 ) && ( intval < 800 ) )        // Short pulse?
   {
-    ir_locvalue = ir_locvalue << 1 ;                 // Shift in a "zero" bit
-    ir_loccount++ ;                                  // Count number of received bits
-    ir_0 = ( ir_0 * 3 + intval ) / 4 ;               // Compute average durartion of a short pulse
+    if ( repeat_step == 2 )                          // Full preamble for repeat seen?
+    {  
+      if (t1 - ir_lasttime < 120000)                 // Repeat shot is expected 108 ms either after last
+      {                                              // initial key or previous repeat  
+        if ((ir_value == 0) && (ir_repeatcode != 0)) // Last IR value has been consumed? repeatcode is valid?
+        {
+          ir_repeatcode = ir_repeatcode + 0x10000 ;  // Increment repeat counter (stored in upper word)
+          ir_value = ir_repeatcode ;                 // And report repeat with incremented repeat counter
+        }                                            // (repeat counter is in upper word of ir_value) 
+        ir_lasttime = t1 ;                           // Reset timer for next repeat shot.
+      }
+      repeat_step = 0 ;                              // Reset repeat search state  
+    } 
+    else 
+    {
+      ir_locvalue = ir_locvalue << 1 ;               // Shift in a "zero" bit
+      ir_loccount++ ;                                // Count number of received bits
+      ir_0 = ( ir_0 * 3 + intval ) / 4 ;             // Compute average durartion of a short pulse
+	}
   }
   else if ( ( intval > 1400 ) && ( intval < 1900 ) ) // Long pulse?
   {
@@ -1716,6 +1735,7 @@ void IRAM_ATTR isr_IR()
   }
   else if ( ir_loccount == 65 )                      // Value is correct after 65 level changes
   {
+    ir_value = 0 ;                                   // Clear all 32 bits of ir_value
     while ( mask_in )                                // Convert 32 bits to 16 bits
     {
       if ( ir_locvalue & mask_in )                   // Bit set in pattern?
@@ -1726,9 +1746,17 @@ void IRAM_ATTR isr_IR()
       mask_out <<= 1 ;                               // Shift output mask 1 position
     }
     ir_loccount = 0 ;                                // Ready for next input
+    ir_repeatcode = ir_value ;                       // Store code for repeat shots
+    ir_lasttime = t1 ;                               // Start timer for detecting valid repeat shots
   }
   else
   {
+    if ((intval > 8500) && (intval < 9500) && (repeat_step == 0))         // Check for repeat: a repeat shot starts 
+      repeat_step++;                                                      // with a 9ms pulse
+    else if ((intval > 2000) && (intval < 2500) && (repeat_step == 1))    // followed by a 2.25ms pulse
+      repeat_step++;
+    else
+      repeat_step = 0;                                                    // Reset repeat shot decoding
     ir_locvalue = 0 ;                                // Reset decoding
     ir_loccount = 0 ;
   }
@@ -2933,24 +2961,72 @@ void scanIR()
   char        mykey[20] ;                                   // For numerated key
   String      val ;                                         // Contents of preference entry
   const char* reply ;                                       // Result of analyzeCmd
+  uint16_t    code ;                                        // The code of the Remote key
+  uint16_t    repeat_count ;                                // Will be increased by every repeated
+                                                            // call to scanIR() until the key is released.
+                                                            // Zero on first detection
 
   if ( ir_value )                                           // Any input?
   {
-    sprintf ( mykey, "ir_%04X", ir_value ) ;                // Form key in preferences
-    if ( nvssearch ( mykey ) )
-    {
-      val = nvsgetstr ( mykey ) ;                           // Get the contents
-      dbgprint ( "IR code %04X received. Will execute %s",
-                 ir_value, val.c_str() ) ;
-      reply = analyzeCmd ( val.c_str() ) ;                  // Analyze command and handle it
-      dbgprint ( reply ) ;                                  // Result for debugging
-    }
-    else
-    {
-      dbgprint ( "IR code %04X received, but not found in preferences!  Timing %d/%d",
-                 ir_value, ir_0, ir_1 ) ;
-    }
+    code = ir_value & 0xffff ;                              // Key code is stored in lower word of ir_value
+    repeat_count = ir_value >> 16 ;                         // Repeat counter in upper word of if_value
     ir_value = 0 ;                                          // Reset IR code received
+    if ( 0 < repeat_count )                                 // Is it a "longpress"?
+    {                                                       // In case of a "longpress", we will first search
+                                                            // for ir_XXXXrY, where XXXX is the HEX code of the
+                                                            // key as usual and Y is the repeat counter in decimal,
+                                                            // just as is, no leading '0'. Example: ir_40BFr20 means
+                                                            // this is the 20th repeat of key with code $0BF. That
+                                                            // translates (roughly) to a press time of (at least) 20 * 100ms
+                                                            // If such a preference is not found, we will search for 
+                                                            // ir_XXXXr, which fires for any repeat count.
+                                                            // That means, ir_XXXXrY takes precedence, if defined for a
+                                                            // specific repeat count, ir_XXXXr will NOT fire.
+                                                            // (BTW: ir_XXXXr0 will never fire. ir_XXXX cannot be masked)
+      bool done = false ;                                   // Will be set to true if specific ir_XXXXrY has been found.
+      dbgprint ( "Longpress IR code %04X received,"
+                 "repeat count is: %d",
+                code, repeat_count ) ;
+      sprintf ( mykey, "ir_%04Xr%d", code , repeat_count) ; // Form key in preferences
+      if ( nvssearch ( mykey ) )                            // Search for specific ir_XXXXrY  
+      {
+        done = true ;                                       // If found, we will not search for ir_XXXXr later
+        val = nvsgetstr ( mykey ) ;                         // Get the contents
+        dbgprint ( "IR code %s received. Will execute %s",
+                  mykey, val.c_str() ) ;
+        reply = analyzeCmd ( val.c_str() ) ;                // Analyze command and handle it
+        dbgprint ( reply ) ;                                // Result for debugging
+      }
+      if ( !done )                                          // Did we not find a specific ir_XXXXrY before?
+      {
+        sprintf ( mykey, "ir_%04Xr", code ) ;               // Form key in preferences
+        if ( nvssearch ( mykey ) )                          // Search for more generic ir_XXXXr
+        {
+          val = nvsgetstr ( mykey ) ;                       // Get the contents
+          dbgprint ( "IR code %s received. Will execute %s",
+                    mykey, val.c_str() ) ;
+          reply = analyzeCmd ( val.c_str() ) ;              // Analyze command and handle it
+          dbgprint ( reply ) ;                              // Result for debugging
+        }
+      }
+    }
+    else                                                    // On first press, do just search for ir_XXXX
+    {
+      sprintf ( mykey, "ir_%04X", ir_value ) ;              // Form key in preferences
+      if ( nvssearch ( mykey ) )
+      {
+        val = nvsgetstr ( mykey ) ;                           // Get the contents
+        dbgprint ( "IR code %04X received. Will execute %s",
+                   ir_value, val.c_str() ) ;
+        reply = analyzeCmd ( val.c_str() ) ;                  // Analyze command and handle it
+        dbgprint ( reply ) ;                                  // Result for debugging
+      }
+      else
+      {
+        dbgprint ( "IR code %04X received, but not found in preferences!  Timing %d/%d",
+                   ir_value, ir_0, ir_1 ) ;
+      }
+	}
   }
 }
 

--- a/Esp32_radio/Esp32_radio.ino
+++ b/Esp32_radio/Esp32_radio.ino
@@ -2984,7 +2984,7 @@ void scanIR()
                                                             // specific repeat count, ir_XXXXr will NOT fire.
                                                             // (BTW: ir_XXXXr0 will never fire. ir_XXXX cannot be masked)
       bool done = false ;                                   // Will be set to true if specific ir_XXXXrY has been found.
-      dbgprint ( "Longpress IR code %04X received,"
+      dbgprint ( "Longpress IR code %04X received, "
                  "repeat count is: %d",
                 code, repeat_count ) ;
       sprintf ( mykey, "ir_%04Xr%d", code , repeat_count) ; // Form key in preferences

--- a/Esp32_radio/Esp32_radio.ino
+++ b/Esp32_radio/Esp32_radio.ino
@@ -3012,12 +3012,12 @@ void scanIR()
     }
     else                                                    // On first press, do just search for ir_XXXX
     {
-      sprintf ( mykey, "ir_%04X", ir_value ) ;              // Form key in preferences
+      sprintf ( mykey, "ir_%04X", code ) ;                  // Form key in preferences
       if ( nvssearch ( mykey ) )
       {
         val = nvsgetstr ( mykey ) ;                           // Get the contents
         dbgprint ( "IR code %04X received. Will execute %s",
-                   ir_value, val.c_str() ) ;
+                   code, val.c_str() ) ;
         reply = analyzeCmd ( val.c_str() ) ;                  // Analyze command and handle it
         dbgprint ( reply ) ;                                  // Result for debugging
       }

--- a/Esp32_radio/Esp32_radio.ino
+++ b/Esp32_radio/Esp32_radio.ino
@@ -3024,7 +3024,7 @@ void scanIR()
       else
       {
         dbgprint ( "IR code %04X received, but not found in preferences!  Timing %d/%d",
-                   ir_value, ir_0, ir_1 ) ;
+                   code, ir_0, ir_1 ) ;
       }
 	}
   }


### PR DESCRIPTION
### General Idea
Currently only the first press of an IR-Remote key is reported to the application. If you hold the key nothing happens. As this is most often the expected behaviour (i. e. for a preset change), there are situations were you would want the radio to recognise longpress events. Namely if pressing Vol+ or Vol- buttons. This can be achieved by the proposed change.

### Application details (how to use the proposed change)
The current approach of handling IR-Events is not altered, but extended. On first press of a key with the code XXXX the preferences are looked up for the existence of the preference setting _ir_XXXX_ and the associated command is executed.
If the key is hold, the preferences are searched for the setting _ir_XXXXr_ and if found, the associated command will be executed.

Consider the example from **defaultprefs.h**. There you find the setting `ir_40BF = upvolume = 2`. To have the radio to react on longpress of that key, you should add to the preferences `ir_40BFr = upvolume = 1`. That will result in a smooth increase of the volume as long as the key is pressed.

The timing distance of repeat events averages around 100ms (could be more or less depending on application load (and the effects of the Nyquist Shannon signal sampling theorem of course and some implementation details of the NEC IR protocol)).

If **DEBUG** is on, you can observe the Serial output. You will notice that a repeat counter is increased for lonpressed keys. Here an arbitrary example for a key that has no associated entries in the preferences:

`21:11:06.848 -> D: IR code 02FD received, but not found in preferences!  Timing 558/1681`

`21:11:06.881 -> D: Longpress IR code 02FD received, repeat count is: 1`

`21:11:07.014 -> D: Longpress IR code 02FD received, repeat count is: 2`

`21:11:07.080 -> D: Longpress IR code 02FD received, repeat count is: 3`

`21:11:07.213 -> D: Longpress IR code 02FD received, repeat count is: 4`

`21:11:07.312 -> D: Longpress IR code 02FD received, repeat count is: 5`

You can hook to a specific repeat of a keypress in the preferences by setting a preference with the pattern _ir_XXXXrY_, where

- _XXXX_ is the hexadecimal code of the key
- _Y_ is the decimal representation of the repeat count (w/o any leading '0')

So, in the example above a preference setting of _ir_02FDr2 = reset_ would result in:

`21:30:35.676 -> D: IR code 02FD received, but not found in preferences!  Timing 560/1680`

`21:30:35.709 -> D: Longpress IR code 02FD received, repeat count is: 1`

`21:30:35.809 -> D: Longpress IR code 02FD received, repeat count is: 2`

`21:30:35.809 -> D: IR code ir_02FDr2 received. Will execute reset`

`21:30:35.809 -> D: Command: reset with parameter 0`

`21:30:35.809 -> D: Command accepted`

`21:30:36.835 -> ets Jul 29 2019 12:21:46`

`21:30:36.835 -> `

`21:30:36.835 -> rst:0xc (SW_CPU_RESET),boot:0x1f (SPI_FAST_FLASH_BOOT)`





The following holds true for every sequence for a keypress of key XXXX on the IR remote:

- the first event generated is always _ir_XXXX_. That is effectively the known behaviour. Nothing will change if only that type of keys are defined in the preferences.
- the repeat events will only be generated, if the previous first event has been "seen" by the application. It is not possible that any _ir_XXXXr_ event is executed before the leading _ir_XXXX_ event has been handled.
- _ir_XXXXr_ events can be defined without any _ir_XXXX_ event, though.
- the sequence is always guaranteed: first event will always be _ir_XXXX_, then _ir_XXXXr1_, _ir_XXXXr2_, _ir_XXXXr3_ and so on.
- the timing between this events is not guaranteed, though it will average around 100ms
- an _ir_XXXXrY_ will fire, if the repeat count equals _Y_ (decimal representation, no leading '0'). If that happens it will shadow an existing preference for _ir_XXXXr_ (so that will NOT fire).
- there is no such event as _ir_XXXXr0_. That means the event _ir_XXXX_ for the first press of the key can not be overridden

### Implementation details

The global variable _ir_value_ is now _uint32_t_. It is still produced by _isr_IR()_ and consumed by _scanIR()_. _isr_IR()_ will set _ir_value_ to something not Zero if meaningful input has been detected, and _scanIR()_ will reset _ir_value_ to Zero if the input has been consumed. Major change: the upper half word of _ir_value_ contains the repeat count. So the sequence for a key press XXXX will be: 0x0000XXXX for the first press followed by 0x0001XXXX, 0x0002XXXX, 0x0003XXXX and so on.

Repeat shots in the NEC IR protocol are coded as frames that start with a 9ms burst (as any dataframe), followed by a 2.25ms space (half of the 4.5ms of a full frame) followed by a 560µs burst. If that pattern is encountered (in _isr_IR()_) it is checked if there has been a valid key press detected within the last 120ms (could be either an initial press or a repeated press). If so, that key press is reported with an increased repeat counter. 

Further more, refer to the comments in the code.



