### PR TITLE
Update main.cpp

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4540,6 +4540,7 @@ void handlebyte_ch ( uint8_t b )
     metaint = 0 ;                                      // No metaint found
     LFcount = 0 ;                                      // For detection end of header
     bitrate = 0 ;                                      // Bitrate still unknown
+    icyname = "" ;                                     // Clear Station name
     dbgprint ( "Switch to HEADER" ) ;
     setdatamode ( HEADER ) ;                           // Handle header
 
@@ -5199,8 +5200,16 @@ const char* analyzeCmd ( const char* par, const char* val )
     }
     else
     {
-      sprintf ( reply, "%s - %s", icyname.c_str(),
-                icystreamtitle.c_str() ) ;            // Streamtitle from metadata
+      if ( icyname != "" )                            // Check for station name
+      {
+        sprintf ( reply, "%s - %s", icyname.c_str(),
+                  icystreamtitle.c_str() ) ;          // Streamtitle from metadata
+      }
+      else
+      {
+         sprintf ( reply, "%s", 
+                 icystreamtitle.c_str() ) ;           // Streamtitle from metadata
+      }
     }
   }
   else if ( argument.startsWith ( "reset" ) )         // Reset request


### PR DESCRIPTION
Station name "icy-name" is not always present in datastream and, when it isn't, the previous station name appears as the prefix to the current track. This change nulls the station name prior to parsing the datastream and also suppresses the hyphen that separates the normal station name from the track name if it is absent.
This my suggested solution to issue #445; I haven't programmed in C++ so this may not be an elegant piece of code and any improvement is welcome.